### PR TITLE
chore: support www.googletagmanager.com fixed #48

### DIFF
--- a/server.go
+++ b/server.go
@@ -152,6 +152,8 @@ func postprocessResponse(upstreamResp *fasthttp.Response, c *fiber.Ctx) error {
 			"ssl.google-analytics.com",
 			"www.google-analytics.com",
 			"google-analytics.com",
+			"www.googletagmanager.com",
+			"googletagmanager.com",
 		}
 		currentHost := getGaxyHostName(c)
 


### PR DESCRIPTION
Added `www.googletagmanager.com` domain