### PR TITLE
Use envconfig to reduce the amount of boilerplate code

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,79 +1,21 @@
 package main
 
 import (
-	"errors"
-	"log"
-	"os"
-	"reflect"
+	"github.com/kelseyhightower/envconfig"
 )
 
 // Config contains config
 type Config struct {
 	RoutePrefix                string `env:"ROUTE_PREFIX"`
-	GoogleOrigin               string `env:"GOOGLE_ORIGIN"`
+	GoogleOrigin               string `env:"GOOGLE_ORIGIN" default:"https://www.google-analytics.com"`
 	InjectParamsFromReqHeaders string `env:"INJECT_PARAMS_FROM_REQ_HEADERS"`
 	SkipParamsFromReqHeaders   string `env:"SKIP_PARAMS_FROM_REQ_HEADERS"`
-	Port                       string `env:"PORT"`
+	Port                       string `env:"PORT" default:"3000"`
 }
 
-func (config *Config) Set(key string, value string) {
-	s := reflect.Indirect(reflect.ValueOf(config))
-	s.FieldByName(key).SetString(value)
-}
-
-func (config *Config) GetEnvKey(key string) (string, error) {
-	t := reflect.TypeOf(*config)
-	field, found := t.FieldByName(key)
-
-	if found == false {
-		return "", errors.New("field not found")
-	}
-
-	return field.Tag.Get("env"), nil
-}
-
-func LoadDefaultConfig() Config {
-	config := Config{
-		RoutePrefix:                "",
-		GoogleOrigin:               "https://www.google-analytics.com",
-		InjectParamsFromReqHeaders: "",
-		SkipParamsFromReqHeaders:   "",
-		Port:                       "3000",
-	}
-
-	return config
-}
-
-// LoadConfig returns a new Config struct
 func LoadConfig() Config {
-	config := LoadDefaultConfig()
-
-	t := reflect.TypeOf(config)
-	v := reflect.Indirect(reflect.ValueOf(&config))
-
-	for i := 0; i < t.NumField(); i++ {
-		key := t.Field(i).Name
-		envName, err := config.GetEnvKey(key)
-		if err != nil {
-			continue
-		}
-
-		currentValue := v.FieldByName(key).String()
-		valueFromEnv := getEnv(envName, currentValue)
-
-		config.Set(key, valueFromEnv)
-	}
-
-	log.Printf("Loaded config: %+v\n\n", config)
+	config := Config{}
+	envconfig.Process("", &config)
 
 	return config
-}
-
-// Simple helper function to read an environment or return a default value
-func getEnv(key string, defaultVal string) string {
-	if value, exists := os.LookupEnv(key); exists {
-		return value
-	}
-
-	return defaultVal
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/gofiber/fiber/v2 v2.38.1
+	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/stretchr/testify v1.8.0
 	github.com/valyala/fasthttp v1.40.0
 )

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/gofiber/fiber/v2 v2.37.1/go.mod h1:j3UslgQeJQP3mNhBxHnLLE8TPqA1Fd/lrl
 github.com/gofiber/fiber/v2 v2.38.1 h1:GEQ/Yt3Wsf2a30iTqtLXlBYJZso0JXPovt/tmj5H9jU=
 github.com/gofiber/fiber/v2 v2.38.1/go.mod h1:t0NlbaXzuGH7I+7M4paE848fNWInZ7mfxI/Er1fTth8=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.15.0 h1:xqfchp4whNFxn5A4XFyyYtitiWI8Hy5EW59jEwcyL6U=
 github.com/klauspost/compress v1.15.0/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=

--- a/server_test.go
+++ b/server_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	config := LoadDefaultConfig()
+	config := LoadConfig()
 	app := Setup(config)
 
 	expectedBody := "pong"
@@ -27,7 +27,7 @@ func TestServer(t *testing.T) {
 }
 
 func TestGAJS(t *testing.T) {
-	config := LoadDefaultConfig()
+	config := LoadConfig()
 	app := Setup(config)
 
 	req := httptest.NewRequest("GET", "/ga.js", nil)
@@ -44,8 +44,8 @@ func TestGAJS(t *testing.T) {
 }
 
 func TestRoutePrefix(t *testing.T) {
-	config := LoadDefaultConfig()
-	config.Set("RoutePrefix", "/prefix")
+	config := LoadConfig()
+	config.RoutePrefix = "/prefix"
 
 	app := Setup(config)
 
@@ -65,7 +65,7 @@ func TestRoutePrefix(t *testing.T) {
 }
 
 func TestContentReplacement(t *testing.T) {
-	config := LoadDefaultConfig()
+	config := LoadConfig()
 	app := Setup(config)
 
 	req := httptest.NewRequest("GET", "/analytics.js", nil)
@@ -80,8 +80,8 @@ func TestContentReplacement(t *testing.T) {
 }
 
 func TestContentReplacementWithCustomEnv(t *testing.T) {
-	config := LoadDefaultConfig()
-	config.Set("GoogleOrigin", "https://www.googletagmanager.com")
+	config := LoadConfig()
+	config.GoogleOrigin = "https://www.googletagmanager.com"
 	app := Setup(config)
 
 	req := httptest.NewRequest("GET", "/gtag.js", nil)
@@ -99,8 +99,8 @@ func TestContentReplacementWithCustomEnv(t *testing.T) {
 }
 
 func TestInjectHeader(t *testing.T) {
-	config := LoadDefaultConfig()
-	config.Set("InjectParamsFromReqHeaders", "x-email__uip,user-agent__ua")
+	config := LoadConfig()
+	config.InjectParamsFromReqHeaders = "x-email__uip,user-agent__ua"
 	app := Setup(config)
 
 	req := httptest.NewRequest("GET", "/collect", nil)
@@ -117,8 +117,8 @@ func TestInjectHeader(t *testing.T) {
 }
 
 func TestContentReplacementWithPrefix(t *testing.T) {
-	config := LoadDefaultConfig()
-	config.Set("RoutePrefix", "/prefix")
+	config := LoadConfig()
+	config.RoutePrefix = "/prefix"
 	app := Setup(config)
 
 	req := httptest.NewRequest("GET", "/prefix/analytics.js", nil)
@@ -133,8 +133,8 @@ func TestContentReplacementWithPrefix(t *testing.T) {
 }
 
 func TestBehindReverseProxy(t *testing.T) {
-	config := LoadDefaultConfig()
-	config.Set("RoutePrefix", "/prefix")
+	config := LoadConfig()
+	config.RoutePrefix = "/prefix"
 	app := Setup(config)
 
 	req := httptest.NewRequest("GET", "/prefix/analytics.js", nil)


### PR DESCRIPTION
There is a well-supported package github.com/kelseyhightower/envconfig that does the same: assigns struct values based on env vars.

If we add it, we can remove a lot of boilerplate code.